### PR TITLE
fix output when single dominant barcode exceeds percentile

### DIFF
--- a/R/calcPercentileBarcodes.R
+++ b/R/calcPercentileBarcodes.R
@@ -41,6 +41,7 @@ calcPercentileBarcodes <- function(dgeObject, percentile = 0.95) {
 
     # find number of barcodes that make up Nth percentile
     len <- length(which(cumsum <= percentile.cutoff))
+    len <- max(1,len)
 
     # fill Nth percentile data frame for plotting below
     d <- data.frame(Sample = factor(samples[i]), NumBarcodes = len)


### PR DESCRIPTION
Added a line to make the number of top percentile barcodes at least 1 when the most dominant barcode is higher than the percentile used.